### PR TITLE
Add the required tokenizer extension for swagger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM tico/composer
 
+# Add the required tokenizer exention which is required for token_get_all in this swagger tool
+RUN apk add --no-cache php7-tokenizer
+
 RUN composer global require -a --prefer-stable zircote/swagger-php
 RUN printf "#!/usr/bin/env sh\nexec $COMPOSER_HOME/vendor/bin/openapi \$@" > /docker-entrypoint.sh
 WORKDIR /app


### PR DESCRIPTION
First of all thanks for `dockerizing` this tool. Recently I found out that it doesn't work anymore. Each run over the Source-Code resulted in the following error:

`Exception: Call to undefined function OpenApi\token_get_all()`

This was reproducible across different machines. After a little bit of searching I found out it was a missing PHP extension. With the changes in this PR the missing extension will be installed using the alpine package manger. 